### PR TITLE
proc: implement redirected out follow

### DIFF
--- a/src/dvc_task/proc/manager.py
+++ b/src/dvc_task/proc/manager.py
@@ -45,7 +45,7 @@ class ProcessManager:
             yield name
 
     def __getitem__(self, key: str) -> "ProcessInfo":
-        info_path = os.path.join(self.wdir, key, f"{key}.json")
+        info_path = self._get_info_path(key)
         try:
             with open(info_path, encoding="utf-8") as fobj:
                 return ProcessInfo.from_dict(json.load(fobj))
@@ -54,7 +54,7 @@ class ProcessManager:
 
     @reraise(FileNotFoundError, KeyError)
     def __setitem__(self, key: str, value: "ProcessInfo"):
-        info_path = os.path.join(self.wdir, key, f"{key}.json")
+        info_path = self._get_info_path(key)
         with open(info_path, "w", encoding="utf-8") as fobj:
             return json.dump(value.asdict(), fobj)
 
@@ -62,6 +62,9 @@ class ProcessManager:
         path = os.path.join(self.wdir, key)
         if os.path.exists(path):
             remove(path)
+
+    def _get_info_path(self, key: str) -> str:
+        return os.path.join(self.wdir, key, f"{key}.json")
 
     def get(self, key: str, default=None) -> "ProcessInfo":
         """Return the specified process."""

--- a/tests/proc/test_manager.py
+++ b/tests/proc/test_manager.py
@@ -16,14 +16,13 @@ from .conftest import PID_RUNNING
 
 
 def test_send_signal(
-    tmp_dir: TmpDir,
     mocker: MockerFixture,
+    process_manager: ProcessManager,
     finished_process: str,
     running_process: str,
 ):
     """Terminate signal should be sent."""
     mock_kill = mocker.patch("os.kill")
-    process_manager = ProcessManager(tmp_dir)
     process_manager.send_signal(running_process, signal.SIGTERM)
     mock_kill.assert_called_once_with(PID_RUNNING, signal.SIGTERM)
 
@@ -37,10 +36,11 @@ def test_send_signal(
 
 
 def test_dead_process(
-    tmp_dir: TmpDir, mocker: MockerFixture, running_process: str
+    mocker: MockerFixture,
+    process_manager: ProcessManager,
+    running_process: str,
 ):
     """Dead process lookup should fail."""
-    process_manager = ProcessManager(tmp_dir)
 
     def side_effect(*args):
         if sys.platform == "win32":
@@ -56,14 +56,13 @@ def test_dead_process(
 
 
 def test_kill(
-    tmp_dir: TmpDir,
     mocker: MockerFixture,
+    process_manager: ProcessManager,
     finished_process: str,
     running_process: str,
 ):
     """Kill signal should be sent."""
     mock_kill = mocker.patch("os.kill")
-    process_manager = ProcessManager(tmp_dir)
     process_manager.kill(running_process)
     if sys.platform == "win32":
         mock_kill.assert_called_once_with(PID_RUNNING, signal.SIGTERM)
@@ -78,14 +77,13 @@ def test_kill(
 
 
 def test_terminate(
-    tmp_dir: TmpDir,
     mocker: MockerFixture,
+    process_manager: ProcessManager,
     running_process: str,
     finished_process: str,
 ):
     """Terminate signal should be sent."""
     mock_kill = mocker.patch("os.kill")
-    process_manager = ProcessManager(tmp_dir)
     process_manager.terminate(running_process)
     mock_kill.assert_called_once_with(PID_RUNNING, signal.SIGTERM)
 
@@ -97,12 +95,12 @@ def test_terminate(
 def test_remove(
     mocker: MockerFixture,
     tmp_dir: TmpDir,
+    process_manager: ProcessManager,
     running_process: str,
     finished_process: str,
 ):
     """Process should be removed."""
     mocker.patch("os.kill", return_value=None)
-    process_manager = ProcessManager(tmp_dir)
     process_manager.remove(finished_process)
     assert not (tmp_dir / finished_process).exists()
     with pytest.raises(ProcessNotTerminatedError):
@@ -113,7 +111,7 @@ def test_remove(
 
 
 @pytest.mark.parametrize("force", [True, False])
-def test_cleanup(
+def test_cleanup(  # pylint: disable=too-many-arguments
     mocker: MockerFixture,
     tmp_dir: TmpDir,
     running_process: str,


### PR DESCRIPTION
- adds `ProcessManager.follow` to follow child process redirected output (`tail -f`)