### PR TITLE
cruft updates: force nox color, single workflow run and setuptools_scm for versioning

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/iterative/py-template",
-  "commit": "46ace5315b5c697135c690bdbc42fd4a898b259a",
+  "commit": "ff752e7a4b071b9bdbaf37dfd8bd6546a21be2cc",
   "context": {
     "cookiecutter": {
       "project_name": "dvc-task",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,17 @@ on:
   release:
     types: [published]
 
+env:
+  FORCE_COLOR: "1"
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repository
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up Python 3.7
       uses: actions/setup-python@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,13 @@ on:
       - main
   pull_request: {}
 
+env:
+  FORCE_COLOR: "1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     timeout-minutes: 10
@@ -19,6 +26,8 @@ jobs:
     steps:
     - name: Check out the repository
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.pyv }}
       uses: actions/setup-python@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
-requires = ["setuptools>=48", "wheel"]
+requires = ["setuptools>=48", "setuptools_scm[toml]>=6.3.1"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
 
 [tool.black]
 line-length = 79

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [metadata]
 description = Extensible task queue used in DVC.
 name = dvc-task
-version = 0.0.6
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 license = Apache-2.0


### PR DESCRIPTION
See https://github.com/iterative/py-template/pull/17. There is a merge conflict, so `update-template` is not able to create a PR on itself.