### PR TITLE
ci: bump tests timeout to 15 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   tests:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Windows tests timed out: https://github.com/iterative/dvc-task/runs/6548550094?check_suite_focus=true.