### PR TITLE
proc: remove custom celery task states

### DIFF
--- a/src/dvc_task/proc/tasks.py
+++ b/src/dvc_task/proc/tasks.py
@@ -15,5 +15,5 @@ def run(  # pylint: disable=unused-argument
     Accepts the same arguments as `proc.process.ManagedProcess`.
     """
     with ManagedProcess(*args, **kwargs) as proc:
-        self.update_state(state="RUNNING", meta=proc.info.asdict())
+        pass
     return proc.info.asdict()


### PR DESCRIPTION
Original thinking for custom states was that DVC exps would update state during each exp subtask. This should be done if/when needed in DVC and not dvc-task.