### PR TITLE
queue worker shutdown: disable restore (#61)

### DIFF
--- a/src/dvc_task/app/filesystem.py
+++ b/src/dvc_task/app/filesystem.py
@@ -5,12 +5,15 @@ from typing import Any, Dict, Generator, Optional
 
 from celery import Celery
 from kombu.message import Message
+from kombu.transport.filesystem import Channel
 from kombu.utils.encoding import bytes_to_str
 from kombu.utils.json import loads
 
 from ..utils import makedirs, remove, unc_path
 
 logger = logging.getLogger(__name__)
+
+Channel.QoS.restore_at_shutdown = False
 
 
 def _get_fs_config(


### PR DESCRIPTION
fix: iterative/dvc#7884
The complete task restored back to the queue causing a task duplication.
Might related to a bug from the celery celery/celery#5663

Follow what in https://github.com/celery/celery/issues/5663#issuecomment-734871162
Disabled the restore_at_shutdown