### PR TITLE
proc: set pgrp in spawned daemon processes

### DIFF
--- a/src/dvc_task/proc/process.py
+++ b/src/dvc_task/proc/process.py
@@ -187,7 +187,7 @@ class ManagedProcess(AbstractContextManager):
 
         Returns: The spawned process PID.
         """
-        proc = mp.Process(
+        proc = _DaemonProcess(
             target=cls._spawn,
             args=args,
             kwargs=kwargs,
@@ -203,3 +203,10 @@ class ManagedProcess(AbstractContextManager):
     def _spawn(cls, *args, **kwargs):
         with cls(*args, **kwargs):
             pass
+
+
+class _DaemonProcess(mp.Process):
+    def run(self):
+        if os.name != "nt":
+            os.setpgid(0, 0)  # pylint: disable=no-member
+        super().run()


### PR DESCRIPTION
Sets pgrp in spawned proc so signals are not forwarded from the original parent. Signal handlers are still inherited (so caller is responsible for configuring SIG_IGN/SIG_DFL/custom handlers as desired)

Fixes https://github.com/iterative/dvc-task/issues/60