### PR TITLE
Better handle for process info dump

### DIFF
--- a/src/dvc_task/proc/manager.py
+++ b/src/dvc_task/proc/manager.py
@@ -1,6 +1,5 @@
 """Serverless process manager."""
 
-import json
 import locale
 import logging
 import os
@@ -49,16 +48,14 @@ class ProcessManager:
     def __getitem__(self, key: str) -> "ProcessInfo":
         info_path = self._get_info_path(key)
         try:
-            with open(info_path, encoding="utf-8") as fobj:
-                return ProcessInfo.from_dict(json.load(fobj))
+            return ProcessInfo.load(info_path)
         except FileNotFoundError as exc:
             raise KeyError from exc
 
     @reraise(FileNotFoundError, KeyError)
     def __setitem__(self, key: str, value: "ProcessInfo"):
         info_path = self._get_info_path(key)
-        with open(info_path, "w", encoding="utf-8") as fobj:
-            return json.dump(value.asdict(), fobj)
+        value.dump(info_path)
 
     def __delitem__(self, key: str) -> None:
         path = os.path.join(self.wdir, key)

--- a/src/dvc_task/proc/process.py
+++ b/src/dvc_task/proc/process.py
@@ -33,9 +33,23 @@ class ProcessInfo:
         """Construct ProcessInfo from the specified dictionary."""
         return cls(**data)
 
+    @classmethod
+    def load(cls, filename: str) -> "ProcessInfo":
+        """Construct the process information from a file."""
+        with open(filename, "r", encoding="utf-8") as fobj:
+            return cls.from_dict(json.load(fobj))
+
     def asdict(self) -> Dict[str, Any]:
         """Return this info as a dictionary."""
         return asdict(self)
+
+    def dump(self, filename: str) -> None:
+        """Dump the process information into a file."""
+        temp_info_file = f"{filename}.{uuid()}"
+        with open(temp_info_file, "w", encoding="utf-8") as fobj:
+            json.dump(self.asdict(), fobj)
+        os.remove(filename)
+        os.rename(temp_info_file, filename)
 
 
 class ManagedProcess(AbstractContextManager):
@@ -132,8 +146,8 @@ class ManagedProcess(AbstractContextManager):
 
     def _dump(self):
         self._make_wdir()
-        with open(self.info_path, "w", encoding="utf-8") as fobj:
-            json.dump(self.info.asdict(), fobj)
+        self.info.dump(self.info_path)
+
         with open(self.pidfile_path, "w", encoding="utf-8") as fobj:
             fobj.write(str(self.pid))
 

--- a/src/dvc_task/proc/process.py
+++ b/src/dvc_task/proc/process.py
@@ -48,8 +48,7 @@ class ProcessInfo:
         temp_info_file = f"{filename}.{uuid()}"
         with open(temp_info_file, "w", encoding="utf-8") as fobj:
             json.dump(self.asdict(), fobj)
-        os.remove(filename)
-        os.rename(temp_info_file, filename)
+        os.replace(temp_info_file, filename)
 
 
 class ManagedProcess(AbstractContextManager):


### PR DESCRIPTION
fix: #53
Currently, the dump and load process info file at a time may cause some
error. Write to a temp file and then rename it eases this problem. But a
final solution would still be required in someday later.