### PR TITLE
release: temporarily unpin kombu to unblock conda release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,8 @@ package_dir=
     =src
 packages = find:
 install_requires=
-    kombu>=5.3.0a1
-    celery>=5.3.0a1,<6
+    celery>=5.2.0,<6
+    kombu
     funcy>=1.17
     shortuuid>=1.0.8
     pywin32>=225; sys_platform == 'win32'
@@ -39,6 +39,7 @@ docs =
     mkdocstrings-python==0.7.0
 tests =
     flaky==3.7.0
+    kombu>=5.3.0a1
     pytest==7.1.2
     pytest-sugar==0.9.4
     pytest-cov==3.0.0


### PR DESCRIPTION
- unpins kombu alpha requirement and moves version check to runtime in FSApp to unblock conda release

Once 5.3.0 (final/non-alpha) is released on pypi it can be repinned

related: https://github.com/iterative/dvc-task/issues/72