### PR TITLE
worker: monitor shuts down worker prematurely

### DIFF
--- a/src/dvc_task/worker/temporary.py
+++ b/src/dvc_task/worker/temporary.py
@@ -8,6 +8,8 @@ from typing import Any, List, Mapping
 from celery import Celery
 from celery.utils.nodenames import default_nodename
 
+from dvc_task.app.filesystem import FSApp
+
 logger = logging.getLogger(__name__)
 
 
@@ -87,6 +89,7 @@ class TemporaryWorker:
             time.sleep(1)
 
         def _tasksets(nodes):
+
             for taskset in (
                 nodes.active(),
                 nodes.scheduled(),
@@ -94,6 +97,9 @@ class TemporaryWorker:
             ):
                 if taskset is not None:
                     yield from taskset.values()
+
+            if isinstance(self.app, FSApp):
+                yield from self.app.iter_queued()
 
         logger.info("monitor: watching celery worker '%s'", nodename)
         while self.app.control.ping(destination=[nodename]):


### PR DESCRIPTION
fix: #77

This bug is because in our heartbeat detecting the `inspect.schedule` and
`inspect.reserved` didn't return current tasks in queue.  The
`inspect.reserved` it will lists tasks that had been prefetched, but we
had disabled this prefetch behavior. It is always empty for now. And the
prematurely shutdown is caused when the it meets the time gap between
two tasks. Here I directly go into the queue directory and return all
of the tasks in the queue to solve this problem.