### PR TITLE
Add locks to process operations to prevent race conditions.

### DIFF
--- a/src/dvc_task/proc/manager.py
+++ b/src/dvc_task/proc/manager.py
@@ -45,12 +45,10 @@ class ProcessManager:
         for name in os.listdir(self.wdir):
             yield name
 
+    @reraise(FileNotFoundError, KeyError)
     def __getitem__(self, key: str) -> "ProcessInfo":
         info_path = self._get_info_path(key)
-        try:
-            return ProcessInfo.load(info_path)
-        except FileNotFoundError as exc:
-            raise KeyError from exc
+        return ProcessInfo.load(info_path)
 
     @reraise(FileNotFoundError, KeyError)
     def __setitem__(self, key: str, value: "ProcessInfo"):


### PR DESCRIPTION
fix: #93

Our old solution on #53, can reduce possibility of race condition, but it still happens occasionally.

1. Add locks to write and read operations to prevent this kind of error.
2. Use reraise to simplify the code in `__getitem__`