### PR TITLE
fsapp: remove pidbox replies on clean

### DIFF
--- a/tests/worker/test_temporary.py
+++ b/tests/worker/test_temporary.py
@@ -24,9 +24,7 @@ def test_start(celery_app: Celery, mocker: MockerFixture):
     assert kwargs["pool"] == TaskPool
     assert kwargs["concurrency"] == 1
     assert kwargs["prefetch_multiplier"] == 1
-    thread.assert_called_once_with(
-        target=worker.monitor, daemon=True, args=(name,), kwargs={"fsapp_clean": False}
-    )
+    thread.assert_called_once_with(target=worker.monitor, daemon=True, args=(name,))
 
 
 @pytest.mark.flaky(


### PR DESCRIPTION
When workers exit they will end up leaving filesystem broker control messages that never expire and will never be ack'd in the future, we should just purge them on `clean`