### PR TITLE
safety: ignore py vulnerabiility

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -45,7 +45,7 @@ def safety(session: nox.Session) -> None:
     """Scan dependencies for insecure packages."""
     session.install(".[dev]")
     session.install("safety")
-    session.run("safety", "check", "--full-report")
+    session.run("safety", "check", "--full-report", "--ignore=51457")
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ docs = [
 ]
 tests = [
   "pytest>=7,<9",
-  "pytest-celery",
+  "pytest-celery<1",
   "pytest-cov>=4.1.0",
   "pytest-mock",
   "pytest-rerunfailures",


### PR DESCRIPTION
It's a test dependency, so it's safe to ignore.

Revert when https://github.com/celery/pytest-celery/pull/305 gets merged.