### PR TITLE
tests: drop pytest-celery from tests dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ docs = [
 ]
 tests = [
   "pytest>=7,<9",
-  "pytest-celery<1",
   "pytest-cov>=4.1.0",
   "pytest-mock",
   "pytest-rerunfailures",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ("celery.contrib.pytest",)


### PR DESCRIPTION
Closes #130.